### PR TITLE
Bug fix: function call is first argument to remotecall_fetch

### DIFF
--- a/lecture5/parallelism_overview.jmd
+++ b/lecture5/parallelism_overview.jmd
@@ -128,7 +128,7 @@ have fetched the result!
 @time begin
     a = Vector{Any}(undef,nworkers())
     @sync for (idx, pid) in enumerate(workers())
-        @async a[idx] = remotecall_fetch(pid, sleep, 2)
+        @async a[idx] = remotecall_fetch(sleep, pid, 2)
     end
 end
 ```


### PR DESCRIPTION
I tried running the code from the lecture 5 notes, but I got an error on the line about `remotecall_fetch`. Looking at the documentation, I think this was just a typo where the arguments got flipped.