### PR TITLE
remove `@inbounds`

### DIFF
--- a/lecture1/Julia is fast.ipynb
+++ b/lecture1/Julia is fast.ipynb
@@ -4478,7 +4478,7 @@
    "source": [
     "function mysum(A)   \n",
     "    s = 0.0  # s = zero(eltype(A))\n",
-    "    #@inbounds @simd for a in A\n",
+    "    #@simd for a in A\n",
     "    for a in A\n",
     "        s += a\n",
     "    end\n",
@@ -4568,7 +4568,7 @@
    "source": [
     "function myfastsum(A)   \n",
     "    s = 0.0  # s = zero(eltype(A))\n",
-    "    @inbounds @simd for a in A  # <-- don't check bounds, parallel on processor\n",
+    "    @simd for a in A  # <-- don't check bounds, parallel on processor\n",
     "        s += a\n",
     "    end\n",
     "    s\n",


### PR DESCRIPTION
In my benchmarks, Julia 1.7 seems to be smart enough to eliminate the bounds check on its own:

```julia
julia> function _sum(A)
           s = 0.0
           for a in A
               s += a
           end
           s
       end
_sum (generic function with 1 method)

julia> function _sum2(A)
           s = 0.0
           @inbounds @simd for a in A
               s += a
           end
           s
       end
_sum2 (generic function with 1 method)

julia> function _sum3(A)
           s = 0.0
           @simd for a in A
               s += a
           end
           s
       end
_sum3 (generic function with 1 method)

julia> using BenchmarkTools

julia> a = rand(10^7);

julia> @benchmark _sum($a)
BenchmarkTools.Trial: 425 samples with 1 evaluation.
 Range (min … max):  10.595 ms …  13.903 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     11.753 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   11.770 ms ± 177.003 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

                                             █▂▁
  ▅▁▁▁▁▁▁▁▁▁▄▁▁▁▁▁▄▁▁▁▁▁▁▁▁▁▁▁▄▁▁▁▁▁▁▁▁▁▁▁▁▁▁███▅▅▅▄▄▄▁▁▄▄▆▁▁▄ ▆
  10.6 ms       Histogram: log(frequency) by time      12.2 ms <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> @benchmark _sum2($a)
BenchmarkTools.Trial: 1024 samples with 1 evaluation.
 Range (min … max):  4.323 ms …   8.279 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     4.850 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   4.877 ms ± 207.137 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

                       █▂▄▅▂▁▁▂▃
  ▂▁▂▂▁▂▁▁▂▁▂▂▂▂▂▁▂▁▂▁██████████▇▆▄▃▃▃▂▂▂▂▂▃▂▂▂▂▂▁▁▁▁▁▂▁▁▁▁▁▂ ▃
  4.32 ms         Histogram: frequency by time        5.55 ms <

 Memory estimate: 0 bytes, allocs estimate: 0.

julia> @benchmark _sum3($a)
BenchmarkTools.Trial: 988 samples with 1 evaluation.
 Range (min … max):  4.117 ms …   8.226 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     4.935 ms               ┊ GC (median):    0.00%
 Time  (mean ± σ):   5.049 ms ± 579.887 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

              ▄█▂
  ▃▃▃▂▁▃▃▃▃▄▅▆███▆▆▅▅▅▄▃▃▂▂▂▂▁▂▂▂▁▁▂▁▁▁▂▂▂▁▂▂▁▁▁▁▁▂▁▂▂▂▂▂▂▂▂▂ ▃
  4.12 ms         Histogram: frequency by time        7.63 ms <

 Memory estimate: 0 bytes, allocs estimate: 0.
```